### PR TITLE
Añadido de listado de clubes por Valor de Mercado

### DIFF
--- a/app/src/main/java/edu/iesam/laligatracker/app/data/local/db/LaLigaTrackerDataBase.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/app/data/local/db/LaLigaTrackerDataBase.kt
@@ -11,7 +11,7 @@ import edu.iesam.laligatracker.features.players.data.local.db.StatsEntity
 
 @Database(
     entities = [ClubEntity::class, PlayersEntity::class, StatsEntity::class],
-    version = 3,
+    version = 5,
     exportSchema = false
 )
 abstract class LaLigaTrackerDataBase : RoomDatabase() {

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/local/db/ClubDbMappers.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/local/db/ClubDbMappers.kt
@@ -5,11 +5,15 @@ import edu.iesam.laligatracker.features.clubs.domain.Club
 fun Club.toEntity(): ClubEntity = ClubEntity(
     this.id,
     this.name,
-    this.image
+    this.image,
+    this.marketValue,
+    this.stadiumSeats
 )
 
 fun ClubEntity.toDomain(): Club = Club(
     this.id,
     this.name,
-    this.image
+    this.image,
+    this.marketValue,
+    this.stadiumSeats
 )

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/local/db/ClubEntity.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/local/db/ClubEntity.kt
@@ -11,5 +11,7 @@ const val CLUB_ID = "club_id"
 class ClubEntity(
     @PrimaryKey @ColumnInfo(name = CLUB_ID) val id: String,
     @ColumnInfo(name = "name") val name: String,
-    @ColumnInfo(name = "image") val image: String
+    @ColumnInfo(name = "image") val image: String,
+    @ColumnInfo(name = "market_value") val marketValue: Int,
+    @ColumnInfo(name = "stadium_seats") val stadiumSeats: Int
 )

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/remote/ClubApiMapper.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/remote/ClubApiMapper.kt
@@ -3,5 +3,5 @@ package edu.iesam.laligatracker.features.clubs.data.remote
 import edu.iesam.laligatracker.features.clubs.domain.Club
 
 fun ClubProfileApiModel.toModel(): Club {
-    return Club(this.id, this.name, this.image)
+    return Club(this.id, this.name, this.image, this.marketValue, this.stadiumSeats)
 }

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/remote/ClubProfileApiModel.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/remote/ClubProfileApiModel.kt
@@ -10,5 +10,7 @@ data class ClubListApiModel(
 data class ClubProfileApiModel(
     @SerializedName("id") val id: String,
     @SerializedName("name") val name: String,
-    @SerializedName("image") val image: String
+    @SerializedName("image") val image: String,
+    @SerializedName("currentMarketValue") val marketValue: Int,
+    @SerializedName("stadiumSeats") val stadiumSeats: Int
 )

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/Club.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/Club.kt
@@ -1,3 +1,3 @@
 package edu.iesam.laligatracker.features.clubs.domain
 
-data class Club(val id: String, val name: String, var image: String)
+data class Club(val id: String, val name: String, var image: String, val marketValue: Int, val stadiumSeats: Int)

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/GetClubsByMarketValueUseCase.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/GetClubsByMarketValueUseCase.kt
@@ -1,0 +1,10 @@
+package edu.iesam.laligatracker.features.clubs.domain
+
+import org.koin.core.annotation.Single
+
+@Single
+class GetClubsByMarketValueUseCase(private val repository: ClubRepository) {
+    suspend operator fun invoke(): List<Club> {
+        return repository.getClubs().toList().sortedByDescending { it.marketValue }
+    }
+}

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/GetClubsUseCase.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/GetClubsUseCase.kt
@@ -5,6 +5,6 @@ import org.koin.core.annotation.Single
 @Single
 class GetClubsUseCase(private val clubRepository: ClubRepository) {
     suspend operator fun invoke(): List<Club> {
-        return clubRepository.getClubs()
+        return clubRepository.getClubs().toList().sortedByDescending { it.stadiumSeats }
     }
 }

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/market/MarketValueAdapter.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/market/MarketValueAdapter.kt
@@ -1,0 +1,23 @@
+package edu.iesam.laligatracker.features.clubs.presentation.market
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
+import edu.iesam.laligatracker.R
+import edu.iesam.laligatracker.features.clubs.domain.Club
+import edu.iesam.laligatracker.features.clubs.presentation.clubs.ClubsDiffUtil
+
+class MarketValueAdapter : ListAdapter<Club, MarketValueViewHolder>(ClubsDiffUtil()) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MarketValueViewHolder {
+        val view =
+            LayoutInflater.from(parent.context)
+                .inflate(R.layout.view_market_value_clubs_item, parent, false)
+        return MarketValueViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = currentList.size
+
+    override fun onBindViewHolder(holder: MarketValueViewHolder, position: Int) {
+        holder.bind(currentList[position])
+    }
+}

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/market/MarketValueDiffUtil.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/market/MarketValueDiffUtil.kt
@@ -1,0 +1,14 @@
+package edu.iesam.laligatracker.features.clubs.presentation.market
+
+import androidx.recyclerview.widget.DiffUtil
+import edu.iesam.laligatracker.features.clubs.domain.Club
+
+class MarketValueDiffUtil : DiffUtil.ItemCallback<Club>() {
+    override fun areItemsTheSame(oldItem: Club, newItem: Club): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(oldItem: Club, newItem: Club): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/market/MarketValueFragment.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/market/MarketValueFragment.kt
@@ -1,17 +1,26 @@
 package edu.iesam.laligatracker.features.clubs.presentation.market
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.LinearLayoutManager
 import edu.iesam.laligatracker.R
 import edu.iesam.laligatracker.databinding.FragmentMarketValueBinding
+import edu.iesam.laligatracker.features.clubs.presentation.clubs.ClubsViewModel
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MarketValueFragment : Fragment() {
 
     private var _binding: FragmentMarketValueBinding? = null
     private val binding get() = _binding!!
+
+    private val marketValueAdapter = MarketValueAdapter()
+
+    private val viewModel: MarketValueViewModel by viewModel()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -23,9 +32,40 @@ class MarketValueFragment : Fragment() {
         return binding.root
     }
 
-    private fun setupView(){
+    private fun setupView() {
         binding.apply {
             marketValueToolbar.toolbar.title = requireContext().getString(R.string.valor_mercado)
+            marketValueList.layoutManager =
+                LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+            marketValueList.adapter = marketValueAdapter
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObserver()
+        viewModel.fetchClubsByMarketValue()
+    }
+
+    private fun setupObserver() {
+        val clubObserver = Observer<MarketValueViewModel.UiState> {
+            it.clubs?.let { clubs ->
+                marketValueAdapter.submitList(clubs)
+            }
+
+            it.errorApp.let {}
+
+            if (it.isLoading) {
+                Log.d("@dev", "Loading...")
+            } else {
+                Log.d("@dev", "Loaded market")
+            }
+        }
+        viewModel.uiState.observe(viewLifecycleOwner, clubObserver)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/market/MarketValueViewHolder.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/market/MarketValueViewHolder.kt
@@ -1,0 +1,22 @@
+package edu.iesam.laligatracker.features.clubs.presentation.market
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import edu.iesam.laligatracker.app.extensions.loadUrl
+import edu.iesam.laligatracker.databinding.ViewClubsItemBinding
+import edu.iesam.laligatracker.databinding.ViewMarketValueClubsItemBinding
+import edu.iesam.laligatracker.features.clubs.domain.Club
+
+class MarketValueViewHolder(private val view: View) : RecyclerView.ViewHolder(view) {
+
+    private lateinit var binding: ViewMarketValueClubsItemBinding
+
+    fun bind(club: Club) {
+        binding = ViewMarketValueClubsItemBinding.bind(view)
+        binding.apply {
+            clubName.text = club.name
+            clubImage.loadUrl(club.image)
+            clubValue.text = club.marketValue.toString()
+        }
+    }
+}

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/market/MarketValueViewModel.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/market/MarketValueViewModel.kt
@@ -1,0 +1,39 @@
+package edu.iesam.laligatracker.features.clubs.presentation.market
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import edu.iesam.laligatracker.features.clubs.domain.Club
+import edu.iesam.laligatracker.features.clubs.domain.GetClubsByMarketValueUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.koin.android.annotation.KoinViewModel
+
+@KoinViewModel
+class MarketValueViewModel(
+    private val getClubsByMarketValueUseCase: GetClubsByMarketValueUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableLiveData<UiState>()
+    val uiState: LiveData<UiState> get() = _uiState
+
+
+    fun fetchClubsByMarketValue() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val clubs = getClubsByMarketValueUseCase.invoke()
+            _uiState.postValue(
+                UiState(
+                    clubs = clubs,
+                    errorApp = false
+                )
+            )
+        }
+    }
+
+    data class UiState(
+        val isLoading: Boolean = false,
+        val errorApp: Boolean = true,
+        val clubs: List<Club>? = null
+    )
+}

--- a/app/src/main/res/layout/fragment_market_value.xml
+++ b/app/src/main/res/layout/fragment_market_value.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/market_value"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -9,14 +10,13 @@
         android:id="@+id/market_value_toolbar"
         layout="@layout/view_toolbar" />
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="@string/valor_mercado"
-        android:textSize="50sp"
-        app:layout_constraintBottom_toBottomOf="parent"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/market_value_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:paddingBottom="@dimen/bottom_club_list_padding"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/market_value_toolbar"
+        tools:listitem="@layout/view_clubs_item" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_market_value_clubs_item.xml
+++ b/app/src/main/res/layout/view_market_value_clubs_item.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/value_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="@dimen/usual_padding">
@@ -22,35 +23,49 @@
             android:padding="@dimen/usual_padding">
 
             <ImageView
-                android:id="@+id/player_image"
+                android:id="@+id/club_image"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 tools:src="@tools:sample/avatars" />
 
-
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:padding="@dimen/usual_padding">
+                android:orientation="vertical">
 
                 <TextView
-                    android:id="@+id/player_name"
+                    android:id="@+id/club_name"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:gravity="center_horizontal"
                     android:padding="@dimen/usual_padding"
                     android:textColor="@color/white"
                     android:textSize="@dimen/club_name_size"
-                    tools:text="Player name" />
+                    tools:text="@string/club_name" />
 
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
                 <TextView
-                    android:id="@+id/number_id"
-                    android:layout_width="@dimen/number_size"
-                    android:layout_height="@dimen/number_size"
+                    android:id="@+id/club_value"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
+                    android:padding="@dimen/usual_padding"
                     android:textColor="@color/white"
-                    android:textSize="@dimen/number_font_size"
-                    tools:text="@string/player_number" />
+                    android:textSize="@dimen/club_name_size"
+                    tools:text="@string/club_value" />
+
+                    <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/club_name_size"
+                    android:text="@string/euros" />
+
+                </LinearLayout>
 
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,4 +3,6 @@
     <dimen name="usual_padding">16dp</dimen>
     <dimen name="bottom_club_list_padding">56dp</dimen>
     <dimen name="club_name_size">20sp</dimen>
+    <dimen name="number_size">60dp</dimen>
+    <dimen name="number_font_size">30sp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,7 @@
     <string name="valor_mercado">Valor de Mercado</string>
     <string name="jugadores">Jugadores</string>
     <string name="club_name">Club Name</string>
+    <string name="club_value">Club Value</string>
+    <string name="player_number">#1</string>
+    <string name="euros">€</string>
 </resources>


### PR DESCRIPTION
## 🤔 Descripción del problema a resolver
Se solicita visualizar el listado de los clubes de la liga en base al valor de mercado y de manera descendente. Además, se requiere que se pueda ver este mismo valor.
## 💡 Proceso seguido para resolver el problema.
En un principio, iba a ser reutilizado gran parte del código, como el **ViewModel** del listado de clubes, ya que el listado es el mismo. Pero, tras realizar algunas pruebas se ha visto que no es posible, ya que se queda guardado el orden de la lista inicial, por lo que el problema se ha planteado añadiendo un nuevo atributo al objeto *Club* y se ha utilizado una función que proporciona **Kotlin** (*sortingByDescending*) para ordenarlos.
## 📝 Pruebas de validación
En los ítems del listado de clubes se muestra el valor de mercado actual y los ordena en base a este valor de manera descendente.
## 👩‍💻 Resumen de los cambios introducidos
Se ha añadido un nuevo caso de uso, además de añadir el nuevo valor a la gestión de datos local y remota. Se ha añadido un nuevo *RecyclerView* para visualizar la nueva lista de clubes. Se ha añadido un nuevo *ViewModel* para la gestión de estados de la vista del nuevo fragmento.
## 📸 Screenshot o Video

https://github.com/user-attachments/assets/b0516df8-2612-45e3-af85-79a74d912343

## ✋ Notas adicionales (Disclaimer)
Falta diseño, ya que actualmente es algo trivial para visualizar los datos. 
Se ha añadido un valor extra: cantidad de asientos del estadio del club. Esto se debe a que, por defecto, la API daba ordenados los clubs ya en base al valor de mercado, o al menos, un orden muy similar. Para no hacer dos fragmentos iguales, he modificado el orden del original para que se ordenen en base a la cantidad de asientos del estadio de club. De esta manera, es muy difícil que coincidan en el orden. 
## 🌈 Añade un Gif que represente a esta PR
![kounde-celebration](https://github.com/user-attachments/assets/3ce1a0ae-319e-4af3-a141-fd00766498f6)

## ✅ Checklist
- [x] La rama tiene el formato correcto: tipo_de_issue/numero_issue/descripcion.
- [x] He añadido un título a la PR descriptivo.
- [x] Me he asignado como autor.
- [x] He asignado a un revisor.
- [x] He relacionado la PR con la Issue.
