### PR TITLE
Añadido filtrado por favoritos

### DIFF
--- a/app/src/main/java/edu/iesam/laligatracker/app/data/local/db/LaLigaTrackerDataBase.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/app/data/local/db/LaLigaTrackerDataBase.kt
@@ -2,19 +2,21 @@ package edu.iesam.laligatracker.app.data.local.db
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import edu.iesam.laligatracker.BuildConfig
 import edu.iesam.laligatracker.features.clubs.data.local.db.ClubEntity
 import edu.iesam.laligatracker.features.clubs.data.local.db.ClubsDao
+import edu.iesam.laligatracker.features.clubs.data.local.db.FavoriteDao
+import edu.iesam.laligatracker.features.clubs.data.local.db.FavoriteEntity
 import edu.iesam.laligatracker.features.players.data.local.db.PlayersDao
 import edu.iesam.laligatracker.features.players.data.local.db.PlayersEntity
 import edu.iesam.laligatracker.features.players.data.local.db.StatsEntity
 
 @Database(
-    entities = [ClubEntity::class, PlayersEntity::class, StatsEntity::class],
-    version = 5,
+    entities = [ClubEntity::class, PlayersEntity::class, StatsEntity::class, FavoriteEntity::class],
+    version = 6,
     exportSchema = false
 )
 abstract class LaLigaTrackerDataBase : RoomDatabase() {
     abstract fun clubsDao(): ClubsDao
     abstract fun playersDao(): PlayersDao
+    abstract fun favoriteDao(): FavoriteDao
 }

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/ClubDataRepository.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/ClubDataRepository.kt
@@ -21,4 +21,20 @@ class ClubDataRepository(
         }
         return clubsLocal
     }
+
+    override suspend fun getFavoriteClubs(): List<Club> {
+        return local.getFavoriteClubs()
+    }
+
+    override suspend fun saveFavoriteClub(club: Club) {
+        local.saveFavorite(club)
+    }
+
+    override suspend fun deleteFavoriteClub(club: Club) {
+        local.deleteFavorite(club)
+    }
+
+    override suspend fun toggleFavoriteClub(club: Club) {
+        local.toggleFavorite(club)
+    }
 }

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/local/db/ClubDbLocalDataSource.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/local/db/ClubDbLocalDataSource.kt
@@ -4,7 +4,7 @@ import edu.iesam.laligatracker.features.clubs.domain.Club
 import org.koin.core.annotation.Single
 
 @Single
-class ClubDbLocalDataSource(private val clubsDao: ClubsDao) {
+class ClubDbLocalDataSource(private val clubsDao: ClubsDao, private val favoriteDao: FavoriteDao) {
 
     suspend fun findAll(): List<Club> {
         val clubs = clubsDao.findAllClubs()
@@ -18,5 +18,36 @@ class ClubDbLocalDataSource(private val clubsDao: ClubsDao) {
             it.toEntity()
         }
         clubsDao.saveAllClubs(*clubsList.toTypedArray())
+    }
+
+    suspend fun findClubById(clubId: String): Club? {
+        return clubsDao.findById(clubId)?.toDomain()
+    }
+
+    suspend fun getFavoriteClubs(): List<Club> {
+        val favoriteEntities = favoriteDao.getFavorites()
+        val favoriteClubs = favoriteEntities.mapNotNull {
+            clubsDao.findById(it.id)?.toDomain()
+        }
+        return favoriteClubs
+    }
+
+    suspend fun saveFavorite(club: Club) {
+        val favoriteEntity = FavoriteEntity(club.id, favorite = true)
+        favoriteDao.addFavorite(favoriteEntity)
+    }
+
+    suspend fun deleteFavorite(club: Club) {
+        val favoriteEntity = FavoriteEntity(club.id, favorite = true)
+        favoriteDao.deleteFavorite(favoriteEntity)
+    }
+
+    suspend fun toggleFavorite(club: Club) {
+        val favoriteEntity = favoriteDao.findById(club.id)
+        if (favoriteEntity == null) {
+            saveFavorite(club)
+        } else {
+            deleteFavorite(club)
+        }
     }
 }

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/local/db/ClubsDao.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/local/db/ClubsDao.kt
@@ -13,4 +13,7 @@ interface ClubsDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun saveAllClubs(vararg clubEntity: ClubEntity)
+
+    @Query("SELECT * FROM $CLUBS_TABLE WHERE club_id = :clubId LIMIT 1")
+    suspend fun findById(clubId: String): ClubEntity?
 }

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/local/db/FavoriteDao.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/local/db/FavoriteDao.kt
@@ -1,0 +1,26 @@
+package edu.iesam.laligatracker.features.clubs.data.local.db
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+
+@Dao
+interface FavoriteDao {
+    @Query("SELECT * FROM $FAVORITE_TABLE WHERE favoriteClub = 1")
+    suspend fun getFavorites(): List<FavoriteEntity>
+
+    @Query("SELECT * FROM $FAVORITE_TABLE WHERE id = :id LIMIT 1")
+    suspend fun findById(id: String): FavoriteEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun addFavorite(vararg favorite: FavoriteEntity)
+
+    @Update
+    suspend fun updateFavorite(vararg favorite: FavoriteEntity)
+
+    @Delete
+    suspend fun deleteFavorite(vararg favorite: FavoriteEntity)
+}

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/local/db/FavoriteEntity.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/data/local/db/FavoriteEntity.kt
@@ -1,0 +1,14 @@
+package edu.iesam.laligatracker.features.clubs.data.local.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+const val FAVORITE_TABLE = "favorite_clubs"
+const val FAVORITE_ID = "id"
+
+@Entity(tableName = FAVORITE_TABLE)
+class FavoriteEntity(
+    @PrimaryKey @ColumnInfo(name = FAVORITE_ID) val id: String,
+    @ColumnInfo(name = "favoriteClub") val favorite: Boolean = false
+)

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/di/ClubModule.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/di/ClubModule.kt
@@ -2,6 +2,7 @@ package edu.iesam.laligatracker.features.clubs.di
 
 import edu.iesam.laligatracker.app.data.local.db.LaLigaTrackerDataBase
 import edu.iesam.laligatracker.features.clubs.data.local.db.ClubsDao
+import edu.iesam.laligatracker.features.clubs.data.local.db.FavoriteDao
 import edu.iesam.laligatracker.features.clubs.data.remote.ClubService
 import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
@@ -18,5 +19,10 @@ class ClubModule {
     @Single
     fun provideClubsDao(db: LaLigaTrackerDataBase): ClubsDao {
         return db.clubsDao()
+    }
+
+    @Single
+    fun provideFavoriteDao(db: LaLigaTrackerDataBase): FavoriteDao {
+        return db.favoriteDao()
     }
 }

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/ClubRepository.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/ClubRepository.kt
@@ -2,4 +2,8 @@ package edu.iesam.laligatracker.features.clubs.domain
 
 interface ClubRepository {
     suspend fun getClubs(): List<Club>
+    suspend fun getFavoriteClubs(): List<Club>
+    suspend fun saveFavoriteClub(club: Club)
+    suspend fun deleteFavoriteClub(club: Club)
+    suspend fun toggleFavoriteClub(club: Club)
 }

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/DeleteFavoriteClubsUseCase.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/DeleteFavoriteClubsUseCase.kt
@@ -1,0 +1,12 @@
+package edu.iesam.laligatracker.features.clubs.domain
+
+import org.koin.core.annotation.Single
+
+@Single
+class DeleteFavoriteClubsUseCase(
+    private val clubRepository: ClubRepository
+) {
+    suspend operator fun invoke(club: Club) {
+        clubRepository.deleteFavoriteClub(club)
+    }
+}

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/GetClubsUseCase.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/GetClubsUseCase.kt
@@ -4,7 +4,25 @@ import org.koin.core.annotation.Single
 
 @Single
 class GetClubsUseCase(private val clubRepository: ClubRepository) {
-    suspend operator fun invoke(): List<Club> {
-        return clubRepository.getClubs().toList().sortedByDescending { it.stadiumSeats }
+    suspend operator fun invoke(): List<ClubFeed> {
+        val resultClubs = clubRepository.getClubs()
+        val favoriteClubs = clubRepository.getFavoriteClubs()
+        val clubsFeed = mutableListOf<ClubFeed>()
+        resultClubs.forEach { club ->
+            clubsFeed.add(
+                ClubFeed(
+                    club,
+                    favoriteClubs.find { favoriteClub ->
+                        favoriteClub.id == club.id
+                    } != null
+                )
+            )
+        }
+        return clubsFeed.sortedByDescending { it.club.stadiumSeats }
     }
+
+    data class ClubFeed(
+        val club: Club,
+        val isFavorite: Boolean
+    )
 }

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/GetFavoriteClubsUseCase.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/GetFavoriteClubsUseCase.kt
@@ -1,0 +1,14 @@
+package edu.iesam.laligatracker.features.clubs.domain
+
+import org.koin.core.annotation.Single
+
+@Single
+class GetFavoriteClubsUseCase(private val clubRepository: ClubRepository) {
+    suspend operator fun invoke(): List<GetClubsUseCase.ClubFeed> {
+        return clubRepository.getFavoriteClubs().map {
+            GetClubsUseCase.ClubFeed(
+                it, true
+            )
+        }
+    }
+}

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/SaveFavoriteClubsUseCase.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/SaveFavoriteClubsUseCase.kt
@@ -1,0 +1,10 @@
+package edu.iesam.laligatracker.features.clubs.domain
+
+import org.koin.core.annotation.Single
+
+@Single
+class SaveFavoriteClubsUseCase(private val clubRepository: ClubRepository) {
+    suspend operator fun invoke(club: Club) {
+        clubRepository.saveFavoriteClub(club)
+    }
+}

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/ToggleFavoriteClubsUseCase.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/domain/ToggleFavoriteClubsUseCase.kt
@@ -1,0 +1,10 @@
+package edu.iesam.laligatracker.features.clubs.domain
+
+import org.koin.core.annotation.Single
+
+@Single
+class ToggleFavoriteClubsUseCase(private val clubRepository: ClubRepository) {
+    suspend operator fun invoke(club: Club){
+        clubRepository.toggleFavoriteClub(club)
+    }
+}

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/clubs/ClubsAdapter.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/clubs/ClubsAdapter.kt
@@ -5,8 +5,16 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import edu.iesam.laligatracker.R
 import edu.iesam.laligatracker.features.clubs.domain.Club
+import edu.iesam.laligatracker.features.clubs.domain.GetClubsUseCase
 
-class ClubsAdapter : ListAdapter<Club, ClubsViewHolder>(ClubsDiffUtil()) {
+class ClubsAdapter : ListAdapter<GetClubsUseCase.ClubFeed, ClubsViewHolder>(ClubsDiffUtil()) {
+
+    private var onItemClick: ((Club) -> Unit)? = null
+
+    fun setOnItemClickListener(listener: (Club) -> Unit) {
+        onItemClick = listener
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ClubsViewHolder {
         val view =
             LayoutInflater.from(parent.context).inflate(R.layout.view_clubs_item, parent, false)
@@ -16,6 +24,6 @@ class ClubsAdapter : ListAdapter<Club, ClubsViewHolder>(ClubsDiffUtil()) {
     override fun getItemCount(): Int = currentList.size
 
     override fun onBindViewHolder(holder: ClubsViewHolder, position: Int) {
-        holder.bind(currentList[position])
+        holder.bind(currentList[position], onItemClick)
     }
 }

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/clubs/ClubsDiffUtil.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/clubs/ClubsDiffUtil.kt
@@ -2,13 +2,20 @@ package edu.iesam.laligatracker.features.clubs.presentation.clubs
 
 import androidx.recyclerview.widget.DiffUtil
 import edu.iesam.laligatracker.features.clubs.domain.Club
+import edu.iesam.laligatracker.features.clubs.domain.GetClubsUseCase
 
-class ClubsDiffUtil : DiffUtil.ItemCallback<Club>() {
-    override fun areItemsTheSame(oldItem: Club, newItem: Club): Boolean {
-        return oldItem.id == newItem.id
+class ClubsDiffUtil : DiffUtil.ItemCallback<GetClubsUseCase.ClubFeed>() {
+    override fun areItemsTheSame(
+        oldItem: GetClubsUseCase.ClubFeed,
+        newItem: GetClubsUseCase.ClubFeed,
+    ): Boolean {
+        return oldItem.club.id == newItem.club.id
     }
 
-    override fun areContentsTheSame(oldItem: Club, newItem: Club): Boolean {
+    override fun areContentsTheSame(
+        oldItem: GetClubsUseCase.ClubFeed,
+        newItem: GetClubsUseCase.ClubFeed,
+    ): Boolean {
         return oldItem == newItem
     }
 }

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/clubs/ClubsFragment.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/clubs/ClubsFragment.kt
@@ -3,14 +3,18 @@ package edu.iesam.laligatracker.features.clubs.presentation.clubs
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
+import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import edu.iesam.laligatracker.R
 import edu.iesam.laligatracker.databinding.FragmentClubsBinding
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuProvider
 
 class ClubsFragment : Fragment() {
 
@@ -20,6 +24,8 @@ class ClubsFragment : Fragment() {
     private val clubsAdapter = ClubsAdapter()
 
     private val viewModel: ClubsViewModel by viewModel()
+
+    private var showingFavorites = false
 
 
     override fun onCreateView(
@@ -36,9 +42,26 @@ class ClubsFragment : Fragment() {
         binding.apply {
             clubsToolbar.toolbar.title = requireContext().getString(R.string.clubes)
             clubsToolbar.imgToolbar.setImageResource(R.drawable.ic_favorite_outlined)
+            favoriteButtonFilter()
             clubsList.layoutManager =
                 LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+            clubsAdapter.setOnItemClickListener {
+                viewModel.toggleFavorite(it, showingFavorites)
+            }
             clubsList.adapter = clubsAdapter
+        }
+    }
+
+    private fun FragmentClubsBinding.favoriteButtonFilter() {
+        clubsToolbar.imgToolbar.setOnClickListener {
+            showingFavorites = !showingFavorites
+            if (showingFavorites) {
+                clubsToolbar.imgToolbar.setImageResource(R.drawable.ic_favorite)
+                viewModel.loadFavorites()
+            } else {
+                clubsToolbar.imgToolbar.setImageResource(R.drawable.ic_favorite_outlined)
+                viewModel.fetchClubs()
+            }
         }
     }
 
@@ -47,6 +70,7 @@ class ClubsFragment : Fragment() {
         setupObserver()
         viewModel.fetchClubs()
     }
+
 
     private fun setupObserver() {
         val clubObserver = Observer<ClubsViewModel.UiState> {

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/clubs/ClubsViewHolder.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/clubs/ClubsViewHolder.kt
@@ -3,26 +3,40 @@ package edu.iesam.laligatracker.features.clubs.presentation.clubs
 import android.view.View
 import androidx.navigation.Navigation.findNavController
 import androidx.recyclerview.widget.RecyclerView
+import edu.iesam.laligatracker.R
 import edu.iesam.laligatracker.app.extensions.loadUrl
 import edu.iesam.laligatracker.databinding.ViewClubsItemBinding
 import edu.iesam.laligatracker.features.clubs.domain.Club
+import edu.iesam.laligatracker.features.clubs.domain.GetClubsUseCase
 
 class ClubsViewHolder(private val view: View) : RecyclerView.ViewHolder(view) {
 
     private lateinit var binding: ViewClubsItemBinding
 
-    fun bind(club: Club) {
+    fun bind(
+        clubFeed: GetClubsUseCase.ClubFeed,
+        onClick: ((Club) -> Unit)?
+    ) {
         binding = ViewClubsItemBinding.bind(view)
         binding.apply {
-            clubName.text = club.name
-            clubImage.loadUrl(club.image)
-            clubItem.setOnClickListener{
-                navigateToDetail(club.id)
+            clubName.text = clubFeed.club.name
+            clubImage.loadUrl(clubFeed.club.image)
+            clubItem.setOnClickListener {
+                navigateToDetail(clubFeed.club.id)
+            }
+            favBtn.setImageResource(
+                if (clubFeed.isFavorite) R.drawable.ic_favorite
+                else R.drawable.ic_favorite_outlined
+            )
+            onClick?.let {
+                favBtn.setOnClickListener {
+                    onClick.invoke(clubFeed.club)
+                }
             }
         }
     }
 
-    private fun navigateToDetail(clubId: String){
+    private fun navigateToDetail(clubId: String) {
         findNavController(view).navigate(
             ClubsFragmentDirections.actionFromClubsToPlayers(clubId = clubId)
         )

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/clubs/ClubsViewModel.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/clubs/ClubsViewModel.kt
@@ -6,12 +6,18 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import edu.iesam.laligatracker.features.clubs.domain.Club
 import edu.iesam.laligatracker.features.clubs.domain.GetClubsUseCase
+import edu.iesam.laligatracker.features.clubs.domain.GetFavoriteClubsUseCase
+import edu.iesam.laligatracker.features.clubs.domain.ToggleFavoriteClubsUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.koin.android.annotation.KoinViewModel
 
 @KoinViewModel
-class ClubsViewModel(private val getClubsUseCase: GetClubsUseCase) : ViewModel() {
+class ClubsViewModel(
+    private val getClubsUseCase: GetClubsUseCase,
+    private val getFavoriteClubUseCase: GetFavoriteClubsUseCase,
+    private val toggleFavoriteClubUseCase: ToggleFavoriteClubsUseCase
+) : ViewModel() {
 
     private val _uiState = MutableLiveData<UiState>()
     val uiState: LiveData<UiState> get() = _uiState
@@ -29,9 +35,58 @@ class ClubsViewModel(private val getClubsUseCase: GetClubsUseCase) : ViewModel()
         }
     }
 
+    fun loadFavorites() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val clubsFavorites = getFavoriteClubUseCase()
+            _uiState.postValue(
+                UiState(
+                    clubs = clubsFavorites,
+                    errorApp = false
+                )
+            )
+        }
+    }
+
+//    fun toggleFavorite(club: Club, isFavoriteView: Boolean) {
+//        viewModelScope.launch(Dispatchers.IO) {
+//            toggleFavoriteClubUseCase(club)
+//            _uiState.value?.clubs?.let { currentClubs ->
+//                val updatedClubs = currentClubs.map {
+//                    if (it.club.id == club.id) it.copy(isFavorite = !it.isFavorite) else it
+//                }
+//                _uiState.postValue(
+//                    UiState(
+//                        clubs = updatedClubs,
+//                        errorApp = false
+//                    )
+//                )
+//            }
+//        }
+//    }
+
+    fun toggleFavorite(club: Club, isFavoriteView: Boolean) {
+        viewModelScope.launch(Dispatchers.IO) {
+            toggleFavoriteClubUseCase(club)
+            _uiState.value?.clubs?.let { currentClubs ->
+                val updatedClubs = currentClubs.mapNotNull {
+                    if (it.club.id == club.id) {
+                        val updatedClub = it.copy(isFavorite = !it.isFavorite)
+                        if (isFavoriteView && !updatedClub.isFavorite) null else updatedClub
+                    } else it
+                }
+                _uiState.postValue(
+                    UiState(
+                        clubs = updatedClubs,
+                        errorApp = false
+                    )
+                )
+            }
+        }
+    }
+
     data class UiState(
         val isLoading: Boolean = false,
         val errorApp: Boolean = true,
-        val clubs: List<Club>? = null
+        val clubs: List<GetClubsUseCase.ClubFeed>? = null
     )
 }

--- a/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/market/MarketValueAdapter.kt
+++ b/app/src/main/java/edu/iesam/laligatracker/features/clubs/presentation/market/MarketValueAdapter.kt
@@ -5,9 +5,8 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import edu.iesam.laligatracker.R
 import edu.iesam.laligatracker.features.clubs.domain.Club
-import edu.iesam.laligatracker.features.clubs.presentation.clubs.ClubsDiffUtil
 
-class MarketValueAdapter : ListAdapter<Club, MarketValueViewHolder>(ClubsDiffUtil()) {
+class MarketValueAdapter : ListAdapter<Club, MarketValueViewHolder>(MarketValueDiffUtil()) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MarketValueViewHolder {
         val view =
             LayoutInflater.from(parent.context)

--- a/app/src/main/res/layout/view_clubs_item.xml
+++ b/app/src/main/res/layout/view_clubs_item.xml
@@ -37,6 +37,15 @@
                 android:textColor="@color/white"
                 android:textSize="@dimen/club_name_size"
                 tools:text="@string/club_name" />
+
+            <ImageView
+                android:id="@+id/fav_btn"
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                android:layout_gravity="center_vertical"
+                android:layout_margin="@dimen/usual_padding"
+                android:src="@drawable/ic_favorite_outlined"
+                app:tint="@color/white"/>
         </LinearLayout>
     </androidx.cardview.widget.CardView>
 

--- a/app/src/main/res/layout/view_clubs_item.xml
+++ b/app/src/main/res/layout/view_clubs_item.xml
@@ -40,8 +40,8 @@
 
             <ImageView
                 android:id="@+id/fav_btn"
-                android:layout_width="50dp"
-                android:layout_height="50dp"
+                android:layout_width="@dimen/favorite_btn_size"
+                android:layout_height="@dimen/favorite_btn_size"
                 android:layout_gravity="center_vertical"
                 android:layout_margin="@dimen/usual_padding"
                 android:src="@drawable/ic_favorite_outlined"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,4 +5,5 @@
     <dimen name="club_name_size">20sp</dimen>
     <dimen name="number_size">60dp</dimen>
     <dimen name="number_font_size">30sp</dimen>
+    <dimen name="favorite_btn_size">50dp</dimen>
 </resources>


### PR DESCRIPTION
## 🤔 Descripción del problema a resolver
Se implementa la funcionalidad para marcar y desmarcar clubes como favoritos, permitiendo filtrar el listado principal desde un botón en la Toolbar para mostrar únicamente los favoritos. La selección de favoritos se guarda de forma persistente, asegurando que se mantenga tras cerrar y volver a abrir la aplicación.
## 💡 Proceso seguido para resolver el problema.
Se ha añadido a los ítems del listado el botón para marcar como favoritos. Se ha modificado la base de datos que actúa como caché, en este caso, se ha creado una nueva tabla que contiene la información para saber si un club es o no favorito. De esta manera conseguimos mantener esa persistencia. Se ha puesto de forma visual tal y como era requerido, si un club está marcado o si marcamos el botón de la Toolbar, el botón se rellena de color.
## 📝 Pruebas de validación
Se ha probado a añadir y eliminar tanto uno como varios clubes y eran visibles al filtrar. También se ha probado a salir y volver a entrar a la aplicación y los clubes  previamente marcados seguían como favoritos.
## 👩‍💻 Resumen de los cambios introducidos
1. Se han añadido nuevos casos de uso, para poder gestionar el estado de los clubes (Añadir club favorito, eliminar club favorito, marcar como favorito...)
2. Se ha agregado la tabla mencionada a la base de datos Room. Se ha añadido también un nuevo DAO, que permite gestionar estos mismos estados en la base de datos.
3. Se ha modificado el ViewModel, ya que ahora no simplemente se muestra un listado de clubes, si no que debe lidiar con los nuevos estados.
4. Se ha modificado la estructura del RecyclerView, ya que se ahora en una misma pantalla se deben mostrar dos listados, dependiendo de si queremos verlos filtrados o no.
5. Se han añadido el botón de favoritos al ítem del listado de clubes.
## 📸 Screenshot o Video

https://github.com/user-attachments/assets/17f19162-0c5a-4d07-9e7c-9e8c1cb938b4


## ✋ Notas adicionales (Disclaimer)
Se ha añadido un findById en el listado de clubes original, que no había sido necesario hasta ahora.
Algunos botones de favoritos se ven cortados, ya que aún falta diseño.
## 🌈 Añade un Gif que represente a esta PR
![ishowspeed-shock](https://github.com/user-attachments/assets/ea708818-cc97-415a-baa8-02906cfaca40)
## ✅ Checklist
- [x] La rama tiene el formato correcto: tipo_de_issue/numero_issue/descripcion.
- [x] He añadido un título a la PR descriptivo.
- [x] Me he asignado como autor.
- [x] He asignado a unrevisor.
- [x] He relacionado la PR con la Issue.
